### PR TITLE
Update to Modeshape 4.4.0 and Wildfly 9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM jboss/wildfly:latest
 
-ENV MODESHAPE_VERSION 4.0.0.Final
+ENV MODESHAPE_VERSION 4.4.0.Final
 
-RUN cd wildfly && curl -o modeshape.zip http://downloads.jboss.org/modeshape/$MODESHAPE_VERSION/modeshape-$MODESHAPE_VERSION-jboss-wf8-dist.zip && unzip -q modeshape.zip && rm modeshape.zip
+RUN cd wildfly && curl -o modeshape.zip http://downloads.jboss.org/modeshape/$MODESHAPE_VERSION/modeshape-$MODESHAPE_VERSION-jboss-wf9-dist.zip && unzip -q modeshape.zip && rm modeshape.zip
 
 CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-c", "standalone-modeshape.xml", "-b", "0.0.0.0"]


### PR DESCRIPTION
The image wasn't working with the latest jboss/wildfly image (wildfly 9) due to compatibility problems with modeshape 4.0.0. This PR updates to Modeshape 4.4.0.
